### PR TITLE
Added Pawn-Package Definition file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+#
+# Package only files
+#
+
+# Compiled Bytecode
+*.amx
+
+# Vendor directory for dependencies
+dependencies/
+
+# Dependency versions lockfile
+pawn.lock
+
+
+#
+# Server/gamemode related files
+#
+
+# compiled settings file
+# keep `samp.json` file on version control
+# but make sure the `rcon_password` field is set externally
+# you can use the environment variable `SAMP_RCON_PASSWORD` to do this.
+server.cfg
+
+# Plugins directory
+plugins/
+
+# binaries
+*.exe
+*.dll
+*.so
+announce
+samp03svr
+samp-npc
+
+# logs
+logs/
+server_log.txt

--- a/pawn.json
+++ b/pawn.json
@@ -1,0 +1,11 @@
+{
+    "entry": "test/maptest.pwn",
+    "output": "test/maptest.amx",
+    "dependencies": ["Southclaws/samp-stdlib", "BigETI/pawn-memory/include"],
+    "builds": [
+        {
+            "name": "test",
+            "includes": ["./include"]
+        }
+    ]
+}

--- a/test/maptest.pwn
+++ b/test/maptest.pwn
@@ -35,8 +35,8 @@ PrintMap(Map:map)
     }
 }
 
-// On filter script init
-public OnFilterScriptInit()
+// entry point
+main()
 {
     new Map:test_map = MAP_NULL, c, buf[128];
     print("\r\n[MAPTEST] Test 1");


### PR DESCRIPTION
- added pawn.json for dependency management, version control and build configuration

- added .gitignore for ignoring unnecessary files

- updated maptest.pwn to use `main()` entrypoint instead of `OnFilterScriptInit()` so it can be used with `sampctl package run`