### PR TITLE
added version constraint to pawn-memory

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -4,7 +4,7 @@
     "entry": "test/maptest.pwn",
     "output": "test/maptest.amx",
     "include_path": "include",
-    "dependencies": ["Southclaws/samp-stdlib", "BigETI/pawn-memory"],
+    "dependencies": ["Southclaws/samp-stdlib", "BigETI/pawn-memory:2.0"],
     "builds": [
         {
             "name": "test",


### PR DESCRIPTION
This is necessary to prevent sampctl from unnecessarily using the GitHub API to check for the latest version constantly.